### PR TITLE
add filter for the url prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Endpoint | HTTP Verb
 */wp-json/jwt-auth/v1/token* | POST
 */wp-json/jwt-auth/v1/token/validate* | POST
 
-NOTE: The endpoint prefix (wp-json) can be changed with the **jtw_url_prefix** filter.
+NOTE: The endpoint prefix (jwt-auth) can be changed with the **jtw_url_prefix** filter.
 
 ##Usage
 ### /wp-json/jwt-auth/v1/token

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ Endpoint | HTTP Verb
 */wp-json/jwt-auth/v1/token* | POST
 */wp-json/jwt-auth/v1/token/validate* | POST
 
+NOTE: The endpoint prefix (wp-json) can be changed with the **jtw_url_prefix** filter.
+
 ##Usage
 ### /wp-json/jwt-auth/v1/token
 
@@ -317,6 +319,13 @@ $data = array(
     'user_nicename' => $user->data->user_nicename,
     'user_display_name' => $user->data->display_name,
 );
+```
+
+###jwt_url_prefix
+The **jwt_url_prefix** filter allows you to change the prefix of the endpoint.
+
+Default value:
+```$this->namespace
 ```
 
 ## Testing

--- a/public/class-jwt-auth-public.php
+++ b/public/class-jwt-auth-public.php
@@ -68,16 +68,26 @@ class Jwt_Auth_Public
     }
 
     /**
+     * Get the URL prefix for the API resource.
+     * 
+     * @return string Prefix.
+    */
+    
+    function get_url_prefix() {
+        return apply_filters( 'jwt_url_prefix', $this->namespace );
+    }
+    
+    /**
      * Add the endpoints to the API
      */
     public function add_api_routes()
     {
-        register_rest_route($this->namespace, 'token', [
+        register_rest_route( get_url_prefix(), 'token', [
             'methods' => 'POST',
             'callback' => array($this, 'generate_token'),
         ]);
 
-        register_rest_route($this->namespace, 'token/validate', array(
+        register_rest_route( get_url_prefix(), 'token/validate', array(
             'methods' => 'POST',
             'callback' => array($this, 'validate_token'),
         ));


### PR DESCRIPTION
It can be useful to be able to set the prefix of the endpoint (jwt-auth), for example when this is being included as part of API documentation then it is useful to have the authorisation in the same namespace as the rest of your endpoints. 

This is already possible with the root prefix:
https://github.com/WP-API/WP-API/issues/1007
