### PR TITLE
Add $user to jwt_auth_token_before_sign-hook

### DIFF
--- a/public/class-jwt-auth-public.php
+++ b/public/class-jwt-auth-public.php
@@ -150,7 +150,7 @@ class Jwt_Auth_Public
         );
 
         /** Let the user modify the token data before the sign. */
-        $token = JWT::encode(apply_filters('jwt_auth_token_before_sign', $token), $secret_key);
+        $token = JWT::encode(apply_filters('jwt_auth_token_before_sign', $token, $user), $secret_key);
 
         /** The token is signed, now create the object with no sensible user data to the client*/
         $data = array(


### PR DESCRIPTION
In order to add info about the $user to JWT, I added extra parameter to the 'jwt_auth_token_before_sign'-hook