### PR TITLE
Improve error message when auth fails, ref #34

### DIFF
--- a/public/class-jwt-auth-public.php
+++ b/public/class-jwt-auth-public.php
@@ -123,9 +123,10 @@ class Jwt_Auth_Public
 
         /** If the authentication fails return a error*/
         if (is_wp_error($user)) {
+            $error_code = $user->get_error_code();
             return new WP_Error(
-                'jwt_auth_failed',
-                __('Invalid Credentials.', 'wp-api-jwt-auth'),
+                '[jwt_auth] '.$error_code,
+                $user->get_error_message($error_code),
                 array(
                     'status' => 403,
                 )


### PR DESCRIPTION
Will return reasons why auth failed, with error codes like: "[jwt_auth] empty_password", "[jwt_auth] incorrect_password" ...