### PR TITLE
allow for other Authorization header schemes

### DIFF
--- a/public/class-jwt-auth-public.php
+++ b/public/class-jwt-auth-public.php
@@ -200,7 +200,8 @@ class Jwt_Auth_Public
         $token = $this->validate_token(false);
 
         if (is_wp_error($token)) {
-            if ($token->get_error_code() != 'jwt_auth_no_auth_header') {
+            if (   $token->get_error_code() != 'jwt_auth_no_auth_header' 
+                && $token->get_error_code() != 'jwt_auth_bad_auth_header') { /** step aside for other schemes e.g. Basic/OAuth */
                 /** If there is a error, store it to show it after see rest_pre_dispatch */
                 $this->jwt_error = $token;
                 return $user;


### PR DESCRIPTION
Allowing this plugin to play well with other Authorisation providing plugins, i.e. OAuth, Basic etc.

Instead of failing heavily when Authorization header is present and not set to Bearer, fail gracefully and pass on to the next 'determine_current_user' filter to see if they can handle the header.