### PR TITLE
Use getallheaders to check for headers

### DIFF
--- a/public/class-jwt-auth-public.php
+++ b/public/class-jwt-auth-public.php
@@ -233,6 +233,13 @@ class Jwt_Auth_Public
         if (!$auth) {
             $auth = isset($_SERVER['REDIRECT_HTTP_AUTHORIZATION']) ?  $_SERVER['REDIRECT_HTTP_AUTHORIZATION'] : false;
         }
+        
+        if (!$auth) {
+            if (function_exists('getallheaders')){
+                $headers = getallheaders();
+                $auth = isset($headers['Authorization']) ? $headers['Authorization'] : false;
+            }
+        }
 
         if (!$auth) {
             return new WP_Error(


### PR DESCRIPTION
I was about to submit a patch for this myself, but discovered that @e-beach has already done all the work. @e-beach: I hope you don't mind that I submit this PR - if you do, let me know and I'll close it and create my own.

The problem this solves is that `Authorization: Bearer <token>` doesn't seem to work for me; using this fix, it works.