### PR TITLE
'Authentication failed' message converted in plain text

### DIFF
--- a/public/class-jwt-auth-public.php
+++ b/public/class-jwt-auth-public.php
@@ -126,7 +126,7 @@ class Jwt_Auth_Public
             $error_code = $user->get_error_code();
             return new WP_Error(
                 '[jwt_auth] '.$error_code,
-                $user->get_error_message($error_code),
+                'Authentication failed: '.$error_code,
                 array(
                     'status' => 403,
                 )


### PR DESCRIPTION
A failed authentication on /token no more returns an HTML message.

Before this commit, the /token endopoint was returning thw Wordpress default error for a failed login. This was an HTML string with a link to recover the password.

Dealing with REST API it's better to always have plain text as a message