### PR TITLE
Add firebase custom token capability implement

### DIFF
--- a/public/class-jwt-auth-public.php
+++ b/public/class-jwt-auth-public.php
@@ -265,7 +265,7 @@ class Jwt_Auth_Public
         /** Get the Secret Key */
         $secret_key = defined('JWT_AUTH_SECRET_KEY') ? JWT_AUTH_SECRET_KEY : false;
         if ($alg == 'RS256') {
-              $secret_key = JWT_AUTH_PUBLIC_KEY;
+              $secret_key = defined('JWT_AUTH_PUBLIC_KEY') ? JWT_AUTH_PUBLIC_KEY : false;
         }
         if (!$secret_key) {
             return new WP_Error(


### PR DESCRIPTION
This PR is similar with #110, but it allows we use OpenSSL (RSA256) type to encode/decode token.

And then, we can use this small plugin to sign in firebase using custom token.

```php
<?php

/**
 * @wordpress-plugin
 * Plugin Name:       JWT Authentication Extension for Firebase
 * Version:           1.0.0
 * Author:            Aotokitsuruya
 */

// If this file is called directly, abort.
if (!defined('WPINC')) {
    die;
}

function wp_firebase_jwt_before_sign( $token, $user ) {
  $firebase_token = array(
    'iss' => JWT_AUTH_ISSUER,
    'sub' => JWT_AUTH_ISSUER,
    'aud' => "https://identitytoolkit.googleapis.com/google.identity.identitytoolkit.v1.IdentityToolkit",
    'exp' => (time() + 3600), // Firebase limited to 1 hours
    'uid' => $user->data->ID
  );

  return array_merge($token, $firebase_token);
}
add_filter( 'jwt_auth_token_before_sign', 'wp_firebase_jwt_before_sign', 10, 2 );
```