### PR TITLE
Cookie-Support for wp-content URIs

### DIFF
--- a/public/class-jwt-auth-public.php
+++ b/public/class-jwt-auth-public.php
@@ -184,7 +184,8 @@ class Jwt_Auth_Public
          **/
         $rest_api_slug = rest_get_url_prefix();
         $valid_api_uri = strpos($_SERVER['REQUEST_URI'], $rest_api_slug);
-        if(!$valid_api_uri){
+	$is_content_req = strpos($_SERVER['REQUEST_URI'], 'wp-content');
+        if(!$valid_api_uri && !$is_content_req){
             return $user;
         }
 
@@ -227,7 +228,7 @@ class Jwt_Auth_Public
          * return the user.
          */
         $auth = isset($_SERVER['HTTP_AUTHORIZATION']) ?  $_SERVER['HTTP_AUTHORIZATION'] : false;
-
+	$auth = isset($_COOKIE['JWT_TOKEN']) ? $_COOKIE['JWT_TOKEN'] : $auth;
 
         /* Double check for different auth header string (server dependent) */
         if (!$auth) {

--- a/public/class-jwt-auth-public.php
+++ b/public/class-jwt-auth-public.php
@@ -227,8 +227,9 @@ class Jwt_Auth_Public
          * Looking for the HTTP_AUTHORIZATION header, if not present just
          * return the user.
          */
-        $auth = isset($_SERVER['HTTP_AUTHORIZATION']) ?  $_SERVER['HTTP_AUTHORIZATION'] : false;
-	$auth = isset($_COOKIE['JWT_TOKEN']) ? $_COOKIE['JWT_TOKEN'] : $auth;
+        $auth = isset($_COOKIE['JWT_TOKEN']) ? $_COOKIE['JWT_TOKEN'] : false;
+        $auth = isset($_SERVER['HTTP_AUTHORIZATION']) ?  $_SERVER['HTTP_AUTHORIZATION'] : $auth;
+	    
 
         /* Double check for different auth header string (server dependent) */
         if (!$auth) {


### PR DESCRIPTION
For my application I need to restrict access to WordPress Media files. Because I can't modify the headers for each request, a Cookie with the token would be very useful.

With this implementation a Cookie JWT_TOKEN can be set which should contain "Bearer TOKEN". If this cookie is present, the token is used for validation.