### PR TITLE
Add slashes to wp_authenticate() arguments.

### DIFF
--- a/public/class-jwt-auth-public.php
+++ b/public/class-jwt-auth-public.php
@@ -105,8 +105,10 @@ class Jwt_Auth_Public
     public function generate_token($request)
     {
         $secret_key = defined('JWT_AUTH_SECRET_KEY') ? JWT_AUTH_SECRET_KEY : false;
-        $username = $request->get_param('username');
-        $password = $request->get_param('password');
+
+        /** wp_authenticate() expect arguments to be slashed, WP REST arguments are unslashed. */
+        $username = wp_slash( $request->get_param('username') );
+        $password = wp_slash( $request->get_param('password') );
 
         /** First thing, check the secret key if not exist return a error*/
         if (!$secret_key) {


### PR DESCRIPTION
`wp_authenticate()` expect arguments to have "slashed" data[1] (`"` encoded as `\"`), but WP REST parameters are unslashed[2].

Use wp_slash() on username and password before calling wp_authenticate().

[1] See `wp_signon()` usage in [trac](https://core.trac.wordpress.org/browser/tags/4.9.8/src/wp-includes/user.php#L33) where slashed `$_POST` data is used directly.
[2] https://make.wordpress.org/core/2016/04/06/rest-api-slashed-data-in-wordpress-4-4-and-4-5/