### PR TITLE
Fix Gutenberg compat vel. infinite loop

### DIFF
--- a/includes/class-jwt-auth.php
+++ b/includes/class-jwt-auth.php
@@ -142,26 +142,7 @@ class Jwt_Auth
         $this->loader->add_action('rest_api_init', $plugin_public, 'add_api_routes');
         $this->loader->add_filter('rest_api_init', $plugin_public, 'add_cors_support');
         $this->loader->add_filter('rest_pre_dispatch', $plugin_public, 'rest_pre_dispatch', 10, 2);
-        /**
-         * Gutenberg fix
-         * Now with Gutenberg the WP API usage is masive and most of the call are in the admin.
-         * The JWT token should be used only when the user is not logged in, aka remote calls.
-         * This validation search for the WordPress logged in cookie if exists the filter on
-         * the determine_current_user hook is not applied.
-         *
-         * @since 1.2.5
-         */
-        $is_user_logged_in = false;
-        foreach ($_COOKIE as $name => $value) {
-            if (strpos($name, 'wordpress_logged_in_') === 0) {
-                $is_user_logged_in = true;
-                break;
-            }
-        }
-        if (!$is_user_logged_in) {
-            $this->loader->add_filter('determine_current_user', $plugin_public, 'determine_current_user', 10);
-
-        }
+        $this->loader->add_filter('determine_current_user', $plugin_public, 'determine_current_user', 10);
     }
 
     /**

--- a/public/class-jwt-auth-public.php
+++ b/public/class-jwt-auth-public.php
@@ -236,7 +236,7 @@ class Jwt_Auth_Public
         if (!$auth) {
             return new WP_Error(
                 'jwt_auth_no_auth_header',
-                __('Authorization header not found.', 'wp-api-jwt-auth'),
+                'Authorization header not found.',
                 array(
                     'status' => 403,
                 )
@@ -251,7 +251,7 @@ class Jwt_Auth_Public
         if (!$token) {
             return new WP_Error(
                 'jwt_auth_bad_auth_header',
-                __('Authorization header malformed.', 'wp-api-jwt-auth'),
+                'Authorization header malformed.',
                 array(
                     'status' => 403,
                 )
@@ -263,7 +263,7 @@ class Jwt_Auth_Public
         if (!$secret_key) {
             return new WP_Error(
                 'jwt_auth_bad_config',
-                __('JWT is not configurated properly, please contact the admin', 'wp-api-jwt-auth'),
+                'JWT is not configurated properly, please contact the admin',
                 array(
                     'status' => 403,
                 )
@@ -278,7 +278,7 @@ class Jwt_Auth_Public
                 /** The iss do not match, return error */
                 return new WP_Error(
                     'jwt_auth_bad_iss',
-                    __('The iss do not match with this server', 'wp-api-jwt-auth'),
+                    'The iss do not match with this server',
                     array(
                         'status' => 403,
                     )
@@ -289,7 +289,7 @@ class Jwt_Auth_Public
                 /** No user id in the token, abort!! */
                 return new WP_Error(
                     'jwt_auth_bad_request',
-                    __('User ID not found in the token', 'wp-api-jwt-auth'),
+                    'User ID not found in the token',
                     array(
                         'status' => 403,
                     )


### PR DESCRIPTION
This PR:

 - removes Gutenberg hack from `1.2.5` release (cookies wasn't the root of problem)
 - removes use of translations at the token validation level (solves infinite loop)

What happen:
Token validation fires on `determine_current_user` hook, and translations which were there was trying to get user preferences, what invokes function to login user, which fires `determine_current_user` again creating an infinite loop, which ends up in 'out of memory' errors and mentioned in gutenberg ticket status code `500`.

```PHP Fatal error:  Out of memory (allocated 161480704) (tried to allocate 262144 bytes) in \wp\wp-includes\class-wp-hook.php on line 310```

Related issue: https://github.com/Tmeister/wp-api-jwt-auth/issues/126