### PR TITLE
Allow customization of 'iss' via filter jwt_auth_token_iss

### DIFF
--- a/public/class-jwt-auth-public.php
+++ b/public/class-jwt-auth-public.php
@@ -139,7 +139,7 @@ class Jwt_Auth_Public
         $expire = apply_filters('jwt_auth_expire', $issuedAt + (DAY_IN_SECONDS * 7), $issuedAt);
 
         $token = array(
-            'iss' => get_bloginfo('url'),
+            'iss' => apply_filters('jwt_auth_token_iss', get_bloginfo('url')),
             'iat' => $issuedAt,
             'nbf' => $notBefore,
             'exp' => $expire,
@@ -274,7 +274,7 @@ class Jwt_Auth_Public
         try {
             $token = JWT::decode($token, $secret_key, array('HS256'));
             /** The Token is decoded now validate the iss */
-            if ($token->iss != get_bloginfo('url')) {
+            if ($token->iss != apply_filters('jwt_auth_token_iss', get_bloginfo('url'))) {
                 /** The iss do not match, return error */
                 return new WP_Error(
                     'jwt_auth_bad_iss',


### PR DESCRIPTION
Allow for a customized 'iss' value via filter hook. Useful when working with a multisite environment.

@Tmeister Thanks for the great plugin. Please consider this change for your next release?