### PR TITLE
added the rest url for non-pretty permalinks

### DIFF
--- a/public/class-jwt-auth-public.php
+++ b/public/class-jwt-auth-public.php
@@ -182,7 +182,7 @@ class Jwt_Auth_Public
          *
          * @since 1.2.3
          **/
-        $rest_api_slug = rest_get_url_prefix();
+        $rest_api_slug = get_option('permalink_structure') ? rest_get_url_prefix() : '?rest_route=/';
         $valid_api_uri = strpos($_SERVER['REQUEST_URI'], $rest_api_slug);
         if (!$valid_api_uri) {
             return $user;


### PR DESCRIPTION
I noticed that when permalinks are turned off, `$this->validate_token()` is never reached because /wp-json/ isn't part of the requested URL. If permalinks are set to plain, the REST API can still be accessed by appending `?rest_route=/` followed by the route. I needed to change this for an app in which I'm forced to use plain permalinks.