### PR TITLE
Slash password before authenticating

### DIFF
--- a/public/class-jwt-auth-public.php
+++ b/public/class-jwt-auth-public.php
@@ -119,7 +119,7 @@ class Jwt_Auth_Public
             );
         }
         /** Try to authenticate the user with the passed credentials*/
-        $user = wp_authenticate($username, $password);
+        $user = wp_authenticate($username, wp_slash($password));
 
         /** If the authentication fails return a error*/
         if (is_wp_error($user)) {


### PR DESCRIPTION
Fixes erroneous 403 response when a password contains a single quote.

When attempting to authenticate with a (correct) password containing quotes, the API returns "403 Forbidden": 
`{
    "code": "[jwt_auth] incorrect_password",
    "message": "...",
    "data": {
        "status": 403
    }
}`

Using wp_slash (https://developer.wordpress.org/reference/functions/wp_slash/) to make sure the password is handled correctly.