### PR TITLE
Fixes "register_rest_route was called incorrectly"

### DIFF
--- a/public/class-jwt-auth-public.php
+++ b/public/class-jwt-auth-public.php
@@ -75,11 +75,13 @@ class Jwt_Auth_Public
         register_rest_route($this->namespace, 'token', array(
             'methods' => 'POST',
             'callback' => array($this, 'generate_token'),
+			'permission_callback' => '__return_true'
         ));
 
         register_rest_route($this->namespace, 'token/validate', array(
             'methods' => 'POST',
             'callback' => array($this, 'validate_token'),
+			'permission_callback' => '__return_true'
         ));
     }
 

--- a/public/class-jwt-auth-public.php
+++ b/public/class-jwt-auth-public.php
@@ -75,13 +75,13 @@ class Jwt_Auth_Public
         register_rest_route($this->namespace, 'token', array(
             'methods' => 'POST',
             'callback' => array($this, 'generate_token'),
-			'permission_callback' => '__return_true'
+            'permission_callback' => '__return_true'
         ));
 
         register_rest_route($this->namespace, 'token/validate', array(
             'methods' => 'POST',
             'callback' => array($this, 'validate_token'),
-			'permission_callback' => '__return_true'
+            'permission_callback' => '__return_true'
         ));
     }
 


### PR DESCRIPTION
Related to https://github.com/Tmeister/wp-api-jwt-auth/issues/207