### PR TITLE
Add explicit permission callback to the REST routes

### DIFF
--- a/public/class-jwt-auth-public.php
+++ b/public/class-jwt-auth-public.php
@@ -75,11 +75,13 @@ class Jwt_Auth_Public
         register_rest_route($this->namespace, 'token', [
             'methods' => 'POST',
             'callback' => array($this, 'generate_token'),
+            'permission_callback' => '__return_true',
         ]);
 
         register_rest_route($this->namespace, 'token/validate', array(
             'methods' => 'POST',
             'callback' => array($this, 'validate_token'),
+            'permission_callback' => '__return_true',
         ));
     }
 


### PR DESCRIPTION
Hi @Tmeister, thanks for your work on this plugin.

This PR explicitly defines the permission callbacks according to the [change introduced in WP 5.5](https://core.trac.wordpress.org/changeset/48526)

Reference: https://developer.wordpress.org/rest-api/extending-the-rest-api/adding-custom-endpoints/#permissions-callback

Grateful if you can integrate this.