### PR TITLE
(fix): headers with basic auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .vscode
+includes/vendor
+includes/vendor/composer

--- a/jwt-auth.php
+++ b/jwt-auth.php
@@ -15,7 +15,7 @@
  * Plugin Name:       JWT Authentication for WP-API
  * Plugin URI:        https://enriquechavez.co
  * Description:       Extends the WP REST API using JSON Web Tokens Authentication as an authentication method.
- * Version:           1.2.6
+ * Version:           1.2.7
  * Author:            Enrique Chavez
  * Author URI:        https://enriquechavez.co
  * License:           GPL-2.0+

--- a/public/class-jwt-auth-public.php
+++ b/public/class-jwt-auth-public.php
@@ -75,11 +75,13 @@ class Jwt_Auth_Public
         register_rest_route($this->namespace, 'token', array(
             'methods' => 'POST',
             'callback' => array($this, 'generate_token'),
+            'permission_callback' => '__return_true'
         ));
 
         register_rest_route($this->namespace, 'token/validate', array(
             'methods' => 'POST',
             'callback' => array($this, 'validate_token'),
+            'permission_callback' => '__return_true'
         ));
     }
 
@@ -235,6 +237,21 @@ class Jwt_Auth_Public
 
         if (!$auth) {
             return new WP_Error(
+                'jwt_auth_no_auth_header',
+                'Authorization header not found.',
+                array(
+                    'status' => 403,
+                )
+            );
+        }
+
+        /*
+         * The HTTP_AUTHORIZATION is present; check if request contains Basic auth header.
+         * Return false.
+         */
+        list($token) = sscanf($auth, 'Basic %s');
+        if ( $token ) {
+             return new WP_Error(
                 'jwt_auth_no_auth_header',
                 'Authorization header not found.',
                 array(

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Tags: wp-json, jwt, json web authentication, wp-api
 Requires at least: 4.2
 Tested up to: 5.6.1
 Requires PHP: 5.3.0
-Stable tag: 1.2.6
+Stable tag: 1.2.7
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -341,6 +341,10 @@ $data = array(
 ###Please read how to configured the plugin https://wordpress.org/plugins/jwt-authentication-for-wp-rest-api/
 
 == Changelog ==
+= 1.2.7 =
+* Fix when request contains basic auth.
+
+
 = 1.2.6 =
 * Cookies && Token compatibility
 * Fix the root problem with gutenberg infinite loops and allow the token validation/generation if the WP cookie exists.


### PR DESCRIPTION
Fixes #212.

If header contains a basic auth authentication, an error is thrown: `Authorization header malformed`; it expects a Bearer token.

This PR fixes this.