### PR TITLE
Silent notice on register_rest_route missing argument

### DIFF
--- a/public/class-jwt-auth-public.php
+++ b/public/class-jwt-auth-public.php
@@ -75,11 +75,13 @@ class Jwt_Auth_Public
         register_rest_route($this->namespace, 'token', array(
             'methods' => 'POST',
             'callback' => array($this, 'generate_token'),
+            'permission_callback' => '__return_true',
         ));
 
         register_rest_route($this->namespace, 'token/validate', array(
             'methods' => 'POST',
             'callback' => array($this, 'validate_token'),
+            'permission_callback' => '__return_true',
         ));
     }
 


### PR DESCRIPTION
This update is needed to match to the rest-api since WordPress 5.5.0.

There is a `_doing_it_wrong` in `./wp-includes/rest-api.php` line 94.