### PR TITLE
Update class-jwt-auth-public.php

### DIFF
--- a/public/class-jwt-auth-public.php
+++ b/public/class-jwt-auth-public.php
@@ -184,7 +184,8 @@ class Jwt_Auth_Public
          **/
         $rest_api_slug = rest_get_url_prefix();
         $valid_api_uri = strpos($_SERVER['REQUEST_URI'], $rest_api_slug);
-        if (!$valid_api_uri) {
+        // if already valid user or invalid url, don't attempt to validate token
+        if ( !$valid_api_uri || $user ) {
             return $user;
         }
 


### PR DESCRIPTION
Allow for Basic Auth, by not attempting to validate Authentication Headers if a valid user has already been determined. See issue #241 current version of WP health check fails when attempting to use basic auth.