### PR TITLE
Fix warning `register_rest_route was called incorrectly.`

### DIFF
--- a/public/class-jwt-auth-public.php
+++ b/public/class-jwt-auth-public.php
@@ -73,13 +73,15 @@ class Jwt_Auth_Public
     public function add_api_routes()
     {
         register_rest_route($this->namespace, 'token', array(
-            'methods' => 'POST',
-            'callback' => array($this, 'generate_token'),
+            'methods'             => 'POST',
+            'callback'            => array($this, 'generate_token'),
+            'permission_callback' => '__return_true',
         ));
 
         register_rest_route($this->namespace, 'token/validate', array(
-            'methods' => 'POST',
-            'callback' => array($this, 'validate_token'),
+            'methods'             => 'POST',
+            'callback'            => array($this, 'validate_token'),
+            'permission_callback' => '__return_true',
         ));
     }
 


### PR DESCRIPTION
Hi @Tmeister :wave: 

I just opened a new pull request that includes a fix to ignore the warning of missing argument: `permission_callback`.

Since WP 5.5.0 there is notice if your registration of REST API route is not including the `permission_callback`, you get the notices:
```
register_rest_route was called incorrectly. The REST API route definition for /jwt-auth/v1/token is missing the required permission_callback argument. For REST API routes that are intended to be public, use __return_true as the permission callback...

register_rest_route was called incorrectly. The REST API route definition for /jwt-auth/v1/token/validate is missing the required permission_callback argument. For REST API routes that are intended to be public, use __return_true as the permission callback...
```

Thanks.