### PR TITLE
Create a unique namespace to load the JWT & Key classes of this plugin

### DIFF
--- a/includes/class-jwt-auth.php
+++ b/includes/class-jwt-auth.php
@@ -105,6 +105,12 @@ class Jwt_Auth {
 		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-jwt-auth-i18n.php';
 
 		/**
+		 * The class responsible for creating a unique namespace to load the JWT & Key 
+		 * classes of this plugin
+		 */
+		require_once plugin_dir_path(dirname(__FILE__)) . 'includes/extend-classes.php';
+
+		/**
 		 * The class responsible for defining all actions that occur in the public-facing
 		 * side of the site.
 		 */

--- a/includes/extend-classes.php
+++ b/includes/extend-classes.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Tmeister\Firebase\JWT;
+
+class JWT extends \Firebase\JWT\JWT
+{
+}
+
+class Key extends \Firebase\JWT\Key
+{
+}

--- a/public/class-jwt-auth-public.php
+++ b/public/class-jwt-auth-public.php
@@ -1,8 +1,8 @@
 <?php
 
 /** Require the JWT library. */
-use Firebase\JWT\JWT;
-use Firebase\JWT\Key;
+use Tmeister\Firebase\JWT\JWT;
+use Tmeister\Firebase\JWT\Key;
 
 /**
  * The public-facing functionality of the plugin.


### PR DESCRIPTION
Related to issue #247

This pull request extends the JWT & Key classes and adds a new unique namespace to be used on the `class-jwt-auth-public.php` file

Like this:

```
use Tmeister\Firebase\JWT\JWT;
use Tmeister\Firebase\JWT\Key;
```