### PR TITLE
Fix the condition where it checks if the request is a REST Request

### DIFF
--- a/public/class-jwt-auth-public.php
+++ b/public/class-jwt-auth-public.php
@@ -203,7 +203,9 @@ class Jwt_Auth_Public {
 		$rest_api_slug = rest_get_url_prefix();
 		$requested_url = sanitize_url( $_SERVER['REQUEST_URI'] );
 		// if we already have a valid user, or we have an invalid url, don't attempt to validate token
-		if ( ! defined( 'REST_REQUEST' ) || ! REST_REQUEST || strpos( $requested_url, $rest_api_slug ) === false || $user ) {
+		$isRestRequestConstantDefined = defined( 'REST_REQUEST' ) && REST_REQUEST;
+		$isRestRequest = $isRestRequestConstantDefined || strpos( $requested_url, $rest_api_slug );
+		if ( $isRestRequest && $user ) {
 			return $user;
 		}
 


### PR DESCRIPTION
Related to issue #257 

I used the below variables to make it easy to read

```
$isRestRequestConstantDefined = defined( 'REST_REQUEST' ) && REST_REQUEST;
$isRestRequest = $isRestRequestConstantDefined || strpos( $requested_url, $rest_api_slug );
if ( $isRestRequest && $user ) {
    return $user;
}
```

If you want it a single line you can use

```
if ( ( ( defined( 'REST_REQUEST' ) && REST_REQUEST ) || strpos( $requested_url, $rest_api_slug ) ) && $user ) {
    return $user;
}
```