### PR TITLE
Fix PHP notices by checking if request headers are set before using

### DIFF
--- a/public/class-jwt-auth-public.php
+++ b/public/class-jwt-auth-public.php
@@ -219,10 +219,10 @@ class Jwt_Auth_Public {
 		/**
 		 * We still need to get the Authorization header and check for the token.
 		 */
-		$auth_header = $_SERVER['HTTP_AUTHORIZATION'] ? sanitize_text_field( $_SERVER['HTTP_AUTHORIZATION'] ) : false;
+		$auth_header = ! empty( $_SERVER['HTTP_AUTHORIZATION'] ) ? sanitize_text_field( $_SERVER['HTTP_AUTHORIZATION'] ) : false;
 		/* Double check for different auth header string (server dependent) */
 		if ( ! $auth_header ) {
-			$auth_header = $_SERVER['REDIRECT_HTTP_AUTHORIZATION'] ? sanitize_text_field( $_SERVER['REDIRECT_HTTP_AUTHORIZATION'] ) : false;
+			$auth_header = ! empty( $_SERVER['REDIRECT_HTTP_AUTHORIZATION'] ) ? sanitize_text_field( $_SERVER['REDIRECT_HTTP_AUTHORIZATION'] ) : false;
 		}
 
 		if ( ! $auth_header ) {


### PR DESCRIPTION
When sending an unauthenticated REST request this plugins generates the following two PHP notices:
```
PHP Notice:  Undefined index: HTTP_AUTHORIZATION in /wp-content/plugins/jwt-authentication-for-wp-rest-api/public/class-jwt-auth-public.php on line 222
PHP Notice:  Undefined index: REDIRECT_HTTP_AUTHORIZATION in /wp-content/plugins/jwt-authentication-for-wp-rest-api/public/class-jwt-auth-public.php on line 225
```
This is due to accessing `$_SERVER['HTTP_AUTHORIZATION']` and `$_SERVER['REDIRECT_HTTP_AUTHORIZATION']` without using `isset()` first. This PR resolves this by first using `empty()` in order to check if the headers are set and not empty.

## Steps to reproduce the issue

1. Enable `WP_DEBUG`.
2. Send an unauthenticated request to for example `/wp-json/`, for example by just visiting that endpoint in the URL.
3. Note the two `Undefined index` notices.

With the changes in this PR this is resolved.