### PR TITLE
Add new hook allow asymmetric encription

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,89 @@ $token = JWT::decode(
 );
 ```
 
+### jwt_auth_token_before_decode
+The **jwt_auth_token_before_decode** allows you to modify the key to use asymmetric algorithms.
+
+Default value:
+
+```php
+<?php
+$token = JWT::decode( 
+        $token, 
+        new Key( apply_filters( 'jwt_auth_token_before_decode', $secret_key, $algorithm ), 
+        $algorithm ) 
+			);
+```
+
+Example with  like RS256 (openssl):
+
+```php
+
+<?php
+
+$privateKey = <<<EOD
+-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEAuzWHNM5f+amCjQztc5QTfJfzCC5J4nuW+L/aOxZ4f8J3Frew
+M2c/dufrnmedsApb0By7WhaHlcqCh/ScAPyJhzkPYLae7bTVro3hok0zDITR8F6S
+JGL42JAEUk+ILkPI+DONM0+3vzk6Kvfe548tu4czCuqU8BGVOlnp6IqBHhAswNMM
+78pos/2z0CjPM4tbeXqSTTbNkXRboxjU29vSopcT51koWOgiTf3C7nJUoMWZHZI5
+HqnIhPAG9yv8HAgNk6CMk2CadVHDo4IxjxTzTTqo1SCSH2pooJl9O8at6kkRYsrZ
+WwsKlOFE2LUce7ObnXsYihStBUDoeBQlGG/BwQIDAQABAoIBAFtGaOqNKGwggn9k
+6yzr6GhZ6Wt2rh1Xpq8XUz514UBhPxD7dFRLpbzCrLVpzY80LbmVGJ9+1pJozyWc
+VKeCeUdNwbqkr240Oe7GTFmGjDoxU+5/HX/SJYPpC8JZ9oqgEA87iz+WQX9hVoP2
+oF6EB4ckDvXmk8FMwVZW2l2/kd5mrEVbDaXKxhvUDf52iVD+sGIlTif7mBgR99/b
+c3qiCnxCMmfYUnT2eh7Vv2LhCR/G9S6C3R4lA71rEyiU3KgsGfg0d82/XWXbegJW
+h3QbWNtQLxTuIvLq5aAryV3PfaHlPgdgK0ft6ocU2de2FagFka3nfVEyC7IUsNTK
+bq6nhAECgYEA7d/0DPOIaItl/8BWKyCuAHMss47j0wlGbBSHdJIiS55akMvnAG0M
+39y22Qqfzh1at9kBFeYeFIIU82ZLF3xOcE3z6pJZ4Dyvx4BYdXH77odo9uVK9s1l
+3T3BlMcqd1hvZLMS7dviyH79jZo4CXSHiKzc7pQ2YfK5eKxKqONeXuECgYEAyXlG
+vonaus/YTb1IBei9HwaccnQ/1HRn6MvfDjb7JJDIBhNClGPt6xRlzBbSZ73c2QEC
+6Fu9h36K/HZ2qcLd2bXiNyhIV7b6tVKk+0Psoj0dL9EbhsD1OsmE1nTPyAc9XZbb
+OPYxy+dpBCUA8/1U9+uiFoCa7mIbWcSQ+39gHuECgYAz82pQfct30aH4JiBrkNqP
+nJfRq05UY70uk5k1u0ikLTRoVS/hJu/d4E1Kv4hBMqYCavFSwAwnvHUo51lVCr/y
+xQOVYlsgnwBg2MX4+GjmIkqpSVCC8D7j/73MaWb746OIYZervQ8dbKahi2HbpsiG
+8AHcVSA/agxZr38qvWV54QKBgCD5TlDE8x18AuTGQ9FjxAAd7uD0kbXNz2vUYg9L
+hFL5tyL3aAAtUrUUw4xhd9IuysRhW/53dU+FsG2dXdJu6CxHjlyEpUJl2iZu/j15
+YnMzGWHIEX8+eWRDsw/+Ujtko/B7TinGcWPz3cYl4EAOiCeDUyXnqnO1btCEUU44
+DJ1BAoGBAJuPD27ErTSVtId90+M4zFPNibFP50KprVdc8CR37BE7r8vuGgNYXmnI
+RLnGP9p3pVgFCktORuYS2J/6t84I3+A17nEoB4xvhTLeAinAW/uTQOUmNicOP4Ek
+2MsLL2kHgL8bLTmvXV4FX+PXphrDKg1XxzOYn0otuoqdAQrkK4og
+-----END RSA PRIVATE KEY-----
+EOD;
+
+$publicKey = <<<EOD
+-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuzWHNM5f+amCjQztc5QT
+fJfzCC5J4nuW+L/aOxZ4f8J3FrewM2c/dufrnmedsApb0By7WhaHlcqCh/ScAPyJ
+hzkPYLae7bTVro3hok0zDITR8F6SJGL42JAEUk+ILkPI+DONM0+3vzk6Kvfe548t
+u4czCuqU8BGVOlnp6IqBHhAswNMM78pos/2z0CjPM4tbeXqSTTbNkXRboxjU29vS
+opcT51koWOgiTf3C7nJUoMWZHZI5HqnIhPAG9yv8HAgNk6CMk2CadVHDo4IxjxTz
+TTqo1SCSH2pooJl9O8at6kkRYsrZWwsKlOFE2LUce7ObnXsYihStBUDoeBQlGG/B
+wQIDAQAB
+-----END PUBLIC KEY-----
+EOD;
+
+define('JWT_AUTH_SECRET_KEY', $privateKey);
+define('JWT_AUTH_PUBLIC_KEY', $publicKey);
+
+// ...
+
+//add the filter to change the algorithm to RS256 (openssl)
+function jwt_auth_algorithm_use_RS256( $algorithm ) {
+	return 'RS256'; //here we return the algorithm to use asymmetric encryption
+}
+add_filter( 'jwt_auth_algorithm', 'jwt_auth_algorithm_use_RS256' );
+
+
+//here we change the key to use the public key
+function change_to_public_key( $key, $algorithm ) {
+	return JWT_AUTH_PUBLIC_KEY;
+}
+add_filter('jwt_auth_token_before_decode','change_to_public_key', 10, 2 );
+
+```
+
+
 ## Testing
 I've created a small app to test the basic functionality of the plugin; you can get the app and read all the details on the [JWT-Client Repo](https://github.com/Tmeister/jwt-client)
 

--- a/public/class-jwt-auth-public.php
+++ b/public/class-jwt-auth-public.php
@@ -357,7 +357,7 @@ class Jwt_Auth_Public {
 				);
 			}
 
-			$token = JWT::decode( $token, new Key( $secret_key, $algorithm ) );
+			$token = JWT::decode( $token, new Key( apply_filters( 'jwt_auth_token_before_decode', $secret_key, $algorithm ), $algorithm ) );
 
 			/** The Token is decoded now validate the iss */
 			if ( $token->iss !== get_bloginfo( 'url' ) ) {

--- a/public/class-jwt-auth-public.php
+++ b/public/class-jwt-auth-public.php
@@ -357,6 +357,7 @@ class Jwt_Auth_Public {
 				);
 			}
 
+			/** Here we can use jwt_auth_token_before_decode to modify the $secret_key in order to allow asymmetric encryption.**/
 			$token = JWT::decode( $token, new Key( apply_filters( 'jwt_auth_token_before_decode', $secret_key, $algorithm ), $algorithm ) );
 
 			/** The Token is decoded now validate the iss */


### PR DESCRIPTION
# Description

Thi PR adds new hook **jwt_auth_token_before_decode** to allow the use of asymmetric encryption

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] This change requires a documentation update

# How has this been tested?

I've used same examples as in the https://github.com/firebase/php-jwt readme

Steps I've foollowed to test it
- add constant in the wp-config.php
- add hooks in functions.php (theme twentytwentyfour)
- used postman /wp-json/jwt-auth/v1/token , to get the token
- used postman /wp-json/jwt-auth/v1/token/validate , to validate the token

**Test Configuration**:
* WordPress version: 6.6.2
* PHP version: 7.4

# Checklist:

- [x] My code follows the style guidelines of this project (WordPress code standards)
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if needed)
- [x] My changes generate no new warnings
- [x] I have described how I made my tests that prove my fix is effective or that my feature works
