### PR TITLE
fix: add null check to enqueue_plugin_assets to prevent TypeError

### DIFF
--- a/admin/class-jwt-auth-admin.php
+++ b/admin/class-jwt-auth-admin.php
@@ -91,7 +91,12 @@ class Jwt_Auth_Admin {
 	 * @return void|null
 	 * @since 1.3.4
 	 */
-	public function enqueue_plugin_assets( string $suffix ) {
+	public function enqueue_plugin_assets( $suffix = '' ) {
+		// Check if $suffix is empty or null
+		if ( empty( $suffix ) ) {
+		    return; // Exit early to prevent further execution
+		}
+		
 		if ( $suffix !== 'settings_page_jwt_authentication' ) {
 			return null;
 		}


### PR DESCRIPTION
# **Added Safeguard in `enqueue_plugin_assets` to Handle Null or Empty `$suffix`**

This pull request introduces a safeguard in the `enqueue_plugin_assets` method to handle cases where the `$suffix` argument is null or empty. This resolves the fatal TypeError caused by passing an invalid value and mitigates potential conflicts with other plugins improperly triggering the `admin_enqueue_scripts` hook.

---

## **Description**

This change ensures that the `enqueue_plugin_assets` method gracefully exits when the `$suffix` argument is null or empty. This prevents errors that may occur due to unexpected arguments passed by other plugins or WordPress hooks.

### **Motivation and Context**
The error was caused by the method being called with a null value for `$suffix`, resulting in a TypeError. Adding a simple validation prevents the error and improves the plugin's robustness.

**Fixes:** This PR addresses a fatal error in the `enqueue_plugin_assets` method caused by a null or empty `$suffix` argument.

---

## **Type of Change**

Please select the type of change this PR introduces:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

---

## **How Has This Been Tested?**

Please describe the tests you performed to validate the changes. Include testing instructions for reviewers.

- [x] Manual testing by replicating scenarios where `$suffix` could be null or empty.
- [x] Tested compatibility with other plugins using the `admin_enqueue_scripts` hook.

### **Test Configuration**:
* **WordPress Version:** 6.7.1
* **PHP Version:** 	7.4.33
* **Plugin Name & Version:** JWT Authentication for WP REST API 1.3.5
* **Plugin B Name & Version:** Event Tickets 5.6

---

## **Checklist**

- [x] My code follows the style guidelines of this project (WordPress coding standards).
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings.
- [x] I have described the tests that prove my fix is effective and that my feature works.

