### PR TITLE
Allow non-JWT tokens without throwing an error

### DIFF
--- a/public/class-jwt-auth-public.php
+++ b/public/class-jwt-auth-public.php
@@ -261,7 +261,7 @@ class Jwt_Auth_Public {
 		$token = $this->validate_token( new WP_REST_Request(), $auth_header );
 
 		if ( is_wp_error( $token ) ) {
-			if ($token->get_error_code() != 'jwt_auth_no_auth_header' && $token->get_error_code() != 'jwt_auth_invalid_token') {
+			if ( $token->get_error_code() != 'jwt_auth_no_auth_header' && $token->get_error_code() != 'jwt_auth_invalid_token' ) {
 				/** If there is an error, store it to show it after see rest_pre_dispatch */
 				$this->jwt_error = $token;
 			}

--- a/public/class-jwt-auth-public.php
+++ b/public/class-jwt-auth-public.php
@@ -261,8 +261,8 @@ class Jwt_Auth_Public {
 		$token = $this->validate_token( new WP_REST_Request(), $auth_header );
 
 		if ( is_wp_error( $token ) ) {
-            if ($token->get_error_code() != 'jwt_auth_no_auth_header' && $token->get_error_code() != 'jwt_auth_invalid_token') {
-                /** If there is an error, store it to show it after see rest_pre_dispatch */
+			if ($token->get_error_code() != 'jwt_auth_no_auth_header' && $token->get_error_code() != 'jwt_auth_invalid_token') {
+				/** If there is an error, store it to show it after see rest_pre_dispatch */
 				$this->jwt_error = $token;
 			}
 

--- a/public/class-jwt-auth-public.php
+++ b/public/class-jwt-auth-public.php
@@ -261,8 +261,8 @@ class Jwt_Auth_Public {
 		$token = $this->validate_token( new WP_REST_Request(), $auth_header );
 
 		if ( is_wp_error( $token ) ) {
-			if ( $token->get_error_code() != 'jwt_auth_no_auth_header' ) {
-				/** If there is an error, store it to show it after see rest_pre_dispatch */
+            if ($token->get_error_code() != 'jwt_auth_no_auth_header' && $token->get_error_code() != 'jwt_auth_invalid_token') {
+                /** If there is an error, store it to show it after see rest_pre_dispatch */
 				$this->jwt_error = $token;
 			}
 


### PR DESCRIPTION
# Description

On some of my sites I have a special Auth-Key that grants access to some RestAPI endpoint. And I send them via Bearer in the Authorization header.
Its not a JWT, just a string.

So when using the plugin I can't access the endpoint because the plugin thinks it needs to validate the JWT and since it can't the plugin just throws the error.

In my opinion it does not make sense to throw an error if it finds an invalid token. If thats the case the plugin should simply assume that the header is not intended for it and pass on the request (without user).

Fixes #(issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

I tested it on two projects on the same route (with a JWT and also with the custom token) and also on roztes where I only allow the JWT auth.

**Test Configuration**:
* WordPress version: 6.7.2 / 6.8
* PHP version: 8.3.10

# Checklist:

- [x] My code follows the style guidelines of this project (WordPress code standards)
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if needed)
- [x] My changes generate no new warnings
- [x] I have described how I made my tests that prove my fix is effective or that my feature works
