### PR TITLE
feat(upsell): gate upgrade CTAs by usage - v1.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A simple plugin to add [JSON Web Token (JWT)](https://tools.ietf.org/html/rfc7519) Authentication to the WP REST API.
 
+Tested up to WordPress 6.9.1.
+
 To know more about JSON Web Tokens, please visit [http://jwt.io](http://jwt.io).
 
 ## Description

--- a/admin/class-jwt-auth-admin.php
+++ b/admin/class-jwt-auth-admin.php
@@ -316,6 +316,7 @@ class Jwt_Auth_Admin
     /**
      * Ensure install date tracking exists.
      *
+     * @since 1.5.0
      * @return void
      */
     public function track_install_date()

--- a/admin/class-jwt-auth-admin.php
+++ b/admin/class-jwt-auth-admin.php
@@ -301,15 +301,26 @@ class Jwt_Auth_Admin
             [$this, 'render_admin_page']
         );
 
-        // Add Token Dashboard submenu item
-        add_submenu_page(
-            'options-general.php',
-            __('Token Dashboard', 'jwt-auth'),
-            __('&nbsp;↳ Token Details 👑', 'jwt-auth'),
-            'manage_options',
-            'jwt_token_dashboard',
-            [$this, 'render_token_dashboard_page']
-        );
+        if (jwt_auth_should_show_upsell()) {
+            add_submenu_page(
+                'options-general.php',
+                __('Token Dashboard', 'jwt-auth'),
+                __('&nbsp;↳ Token Details 👑', 'jwt-auth'),
+                'manage_options',
+                'jwt_token_dashboard',
+                [$this, 'render_token_dashboard_page']
+            );
+        }
+    }
+
+    /**
+     * Ensure install date tracking exists.
+     *
+     * @return void
+     */
+    public function track_install_date()
+    {
+        jwt_auth_track_install_date();
     }
 
     /**
@@ -616,12 +627,14 @@ class Jwt_Auth_Admin
             );
         }
 
+        $upsell_metrics = jwt_auth_get_upsell_metrics();
+
         // Provide WordPress API configuration to React app
         if ($is_dev_mode) {
             // For dev mode, we need to add the config manually since we're not using wp_enqueue_script
             add_action(
                 'admin_footer',
-                function () {
+                function () use ($upsell_metrics) {
                     $config = [
                         'apiUrl' => rest_url('jwt-auth/v1/admin/settings'),
                         'nonce' => wp_create_nonce('wp_rest'),
@@ -634,6 +647,11 @@ class Jwt_Auth_Admin
                             'isWooCommerceDetected' => class_exists('WooCommerce'),
                             'pluginCount' => count(get_option('active_plugins', [])),
                             'signingAlgorithm' => 'HS256',
+                        ],
+                        'upsell' => [
+                            'shouldShowUpsell' => (bool) $upsell_metrics['shouldShowUpsell'],
+                            'daysActive' => (int) $upsell_metrics['daysActive'],
+                            'tokensCreated' => (int) $upsell_metrics['tokensCreated'],
                         ],
                     ];
                     echo '<script>window.jwtAuthConfig = '.wp_json_encode($config).';</script>';
@@ -649,14 +667,19 @@ class Jwt_Auth_Admin
                     'nonce' => wp_create_nonce('wp_rest'),
                     'siteUrl' => get_bloginfo('url'),
                     'settings' => get_option('jwt_auth_options', ['share_data' => false]),
-                    'siteProfile' => [
-                        'phpVersion' => PHP_VERSION,
-                        'wordpressVersion' => get_bloginfo('version'),
-                        'isProCompatible' => version_compare(PHP_VERSION, '7.4', '>='),
-                        'isWooCommerceDetected' => class_exists('WooCommerce'),
-                        'pluginCount' => count(get_option('active_plugins', [])),
-                        'signingAlgorithm' => 'HS256',
-                    ],
+                        'siteProfile' => [
+                            'phpVersion' => PHP_VERSION,
+                            'wordpressVersion' => get_bloginfo('version'),
+                            'isProCompatible' => version_compare(PHP_VERSION, '7.4', '>='),
+                            'isWooCommerceDetected' => class_exists('WooCommerce'),
+                            'pluginCount' => count(get_option('active_plugins', [])),
+                            'signingAlgorithm' => 'HS256',
+                        ],
+                        'upsell' => [
+                            'shouldShowUpsell' => (bool) $upsell_metrics['shouldShowUpsell'],
+                            'daysActive' => (int) $upsell_metrics['daysActive'],
+                            'tokensCreated' => (int) $upsell_metrics['tokensCreated'],
+                        ],
                 ]
             );
         }
@@ -810,28 +833,7 @@ class Jwt_Auth_Admin
      */
     public function add_action_link(array $links, string $file): array
     {
-
-        if ($file === 'jwt-authentication-for-wp-rest-api/jwt-auth.php') {
-            // Fixed CTA for high-traffic plugin list (no rotation)
-            $selected_variation = [
-                'text' => '<b>Add Token Dashboard</b>',
-                'utm_content' => 'token-dashboard-primary',
-            ];
-
-            $base_pro_url = 'https://jwtauth.pro/upgrade';
-            $utm_params = [
-                'utm_source' => 'plugin-list',
-                'utm_medium' => 'action-link',
-                'utm_campaign' => 'feature-highlight',
-                'utm_content' => $selected_variation['utm_content'],
-            ];
-
-            $pro_link_url = (string) add_query_arg($utm_params, $base_pro_url);
-            $pro_link_style = 'style="color: #00a32a; font-weight: 700; text-decoration: none;" onmouseover="this.style.color=\'#008a20\';" onmouseout="this.style.color=\'#00a32a\';"';
-
-            $pro_link_text = $selected_variation['text'];
-            $links[] = '<a href="'.esc_url($pro_link_url).'" target="_blank" '.$pro_link_style.' rel="noopener noreferrer">'.$pro_link_text.'</a>';
-        }
+        unset($file);
 
         return $links;
     }
@@ -1085,6 +1087,7 @@ class Jwt_Auth_Admin
             }
 
             $dismissal_data = $dismissal_response->get_data();
+            $upsell_metrics = jwt_auth_get_upsell_metrics();
 
             // Return consolidated data
             return new WP_REST_Response(
@@ -1093,6 +1096,11 @@ class Jwt_Auth_Admin
                     'jwtStatus' => $status_data,
                     'surveyStatus' => $survey_status_data,
                     'surveyDismissal' => $dismissal_data,
+                    'upsell' => [
+                        'shouldShowUpsell' => (bool) $upsell_metrics['shouldShowUpsell'],
+                        'daysActive' => (int) $upsell_metrics['daysActive'],
+                        'tokensCreated' => (int) $upsell_metrics['tokensCreated'],
+                    ],
                 ],
                 200
             );

--- a/admin/ui/src/components/Dashboard.tsx
+++ b/admin/ui/src/components/Dashboard.tsx
@@ -17,6 +17,8 @@ export default function Dashboard() {
   const [isSurveyCtaVisible, setIsSurveyCtaVisible] = useState(false)
   const [shouldShowSurveyCta, setShouldShowSurveyCta] = useState(false)
   const [shouldShowUpsell, setShouldShowUpsell] = useState(false)
+  const [tokensCreated, setTokensCreated] = useState(0)
+  const [daysActive, setDaysActive] = useState(0)
   const [hasLoadedDashboardData, setHasLoadedDashboardData] = useState(false)
   const [surveyCompleted, setSurveyCompleted] = useState(false)
   const [isLoadingDismissal, setIsLoadingDismissal] = useState(false)
@@ -63,6 +65,8 @@ export default function Dashboard() {
           setConfigStatus(dashboardData.jwtStatus)
           setSurveyCompleted(dashboardData.surveyStatus.completed ?? false)
           setShouldShowUpsell(dashboardData.upsell?.shouldShowUpsell ?? false)
+          setTokensCreated(dashboardData.upsell?.tokensCreated ?? 0)
+          setDaysActive(dashboardData.upsell?.daysActive ?? 0)
           setShouldShowSurveyCta(
             (dashboardData.upsell?.shouldShowUpsell ?? false) &&
               (dashboardData.surveyDismissal.shouldShow ?? false) &&
@@ -185,7 +189,11 @@ export default function Dashboard() {
             <div className="jwt-grid jwt-grid-cols-1 lg:jwt-grid-cols-2 jwt-gap-8">
               <ConfigurationHealthCheck configStatus={configStatus} />
               {isJwtConfigured ? (
-                <SystemEnvironment configStatus={configStatus} />
+                <SystemEnvironment
+                  configStatus={configStatus}
+                  tokensCreated={tokensCreated}
+                  daysActive={daysActive}
+                />
               ) : (
                 <SetupConfiguration />
               )}
@@ -204,6 +212,7 @@ export default function Dashboard() {
         currentPage={currentPage}
         onPageChange={handlePageChange}
         shouldShowUpsell={shouldShowUpsell}
+        tokensCreated={tokensCreated}
       />
       <main className="jwt-flex-1 jwt-p-6 sm:jwt-p-8 lg:jwt-p-12 jwt-container jwt-mx-auto">
         {renderPage()}

--- a/admin/ui/src/components/Dashboard.tsx
+++ b/admin/ui/src/components/Dashboard.tsx
@@ -16,6 +16,8 @@ export default function Dashboard() {
   const [configStatus, setConfigStatus] = useState<ConfigurationStatus | null>(null)
   const [isSurveyCtaVisible, setIsSurveyCtaVisible] = useState(false)
   const [shouldShowSurveyCta, setShouldShowSurveyCta] = useState(false)
+  const [shouldShowUpsell, setShouldShowUpsell] = useState(false)
+  const [hasLoadedDashboardData, setHasLoadedDashboardData] = useState(false)
   const [surveyCompleted, setSurveyCompleted] = useState(false)
   const [isLoadingDismissal, setIsLoadingDismissal] = useState(false)
 
@@ -60,14 +62,20 @@ export default function Dashboard() {
           setShareData(dashboardData.settings.share_data ?? false)
           setConfigStatus(dashboardData.jwtStatus)
           setSurveyCompleted(dashboardData.surveyStatus.completed ?? false)
+          setShouldShowUpsell(dashboardData.upsell?.shouldShowUpsell ?? false)
           setShouldShowSurveyCta(
-            (dashboardData.surveyDismissal.shouldShow ?? false) &&
+            (dashboardData.upsell?.shouldShowUpsell ?? false) &&
+              (dashboardData.surveyDismissal.shouldShow ?? false) &&
               !(dashboardData.surveyStatus.completed ?? false)
           )
         }
       } catch (error) {
         if (!isCancelled) {
           console.error('Failed to load dashboard data:', error)
+        }
+      } finally {
+        if (!isCancelled) {
+          setHasLoadedDashboardData(true)
         }
       }
     }
@@ -79,6 +87,17 @@ export default function Dashboard() {
       isCancelled = true
     }
   }, [])
+
+  useEffect(() => {
+    if (
+      hasLoadedDashboardData &&
+      !shouldShowUpsell &&
+      (currentPage === 'token-dashboard' || currentPage === 'survey')
+    ) {
+      setCurrentPage('overview')
+      window.history.replaceState(null, '', '#overview')
+    }
+  }, [currentPage, hasLoadedDashboardData, shouldShowUpsell])
 
   // Listen for hash changes to support back/forward navigation
   useEffect(() => {
@@ -150,7 +169,12 @@ export default function Dashboard() {
           />
         )
       case 'token-dashboard':
-        return <TokenDashboard onBackToDashboard={() => handlePageChange('overview')} />
+        return (
+          <TokenDashboard
+            onBackToDashboard={() => handlePageChange('overview')}
+            shouldShowUpsell={shouldShowUpsell}
+          />
+        )
       case 'overview':
       default: {
         const isJwtConfigured = configStatus?.configuration?.secret_key_configured ?? false
@@ -176,13 +200,18 @@ export default function Dashboard() {
 
   return (
     <div className="jwt-flex jwt-flex-col jwt-min-h-screen jwt-bg-gray-50">
-      <Topbar currentPage={currentPage} onPageChange={handlePageChange} />
+      <Topbar
+        currentPage={currentPage}
+        onPageChange={handlePageChange}
+        shouldShowUpsell={shouldShowUpsell}
+      />
       <main className="jwt-flex-1 jwt-p-6 sm:jwt-p-8 lg:jwt-p-12 jwt-container jwt-mx-auto">
         {renderPage()}
       </main>
       <FloatingSurveyCTA
         isVisible={
           isSurveyCtaVisible &&
+          shouldShowUpsell &&
           currentPage !== 'survey' &&
           currentPage !== 'token-dashboard' &&
           !isLoadingDismissal

--- a/admin/ui/src/components/dashboard/system-environment.tsx
+++ b/admin/ui/src/components/dashboard/system-environment.tsx
@@ -6,9 +6,15 @@ import type { ConfigurationStatus } from '@/lib/wordpress-api'
 
 interface SystemEnvironmentProps {
   configStatus: ConfigurationStatus | null
+  tokensCreated: number
+  daysActive: number
 }
 
-export const SystemEnvironment = ({ configStatus }: SystemEnvironmentProps) => {
+export const SystemEnvironment = ({
+  configStatus,
+  tokensCreated,
+  daysActive,
+}: SystemEnvironmentProps) => {
   if (!configStatus) {
     return (
       <InfoCard title="System Environment Check" description="Loading system information...">
@@ -21,6 +27,8 @@ export const SystemEnvironment = ({ configStatus }: SystemEnvironmentProps) => {
 
   const { system } = configStatus
   const allCompatible = system.php_compatible
+  const trackingPeriodLabel =
+    daysActive <= 0 ? 'since today' : daysActive === 1 ? 'since 1 day' : `since ${daysActive} days`
 
   return (
     <InfoCard
@@ -49,8 +57,10 @@ export const SystemEnvironment = ({ configStatus }: SystemEnvironmentProps) => {
         <span className="jwt-mr-2">{system.mysql_version}</span>
         <Check />
       </StatusRow>
-      <StatusRow label="Post Max Size">
-        <span className="jwt-mr-2">{system.post_max_size}</span>
+      <StatusRow label={<span className="jwt-font-bold jwt-text-slate-800">Tokens Generated</span>}>
+        <span className="jwt-mr-2">
+          <span className="jwt-font-bold">{tokensCreated}</span> {trackingPeriodLabel}
+        </span>
         <Check />
       </StatusRow>
     </InfoCard>

--- a/admin/ui/src/components/dashboard/token-dashboard.tsx
+++ b/admin/ui/src/components/dashboard/token-dashboard.tsx
@@ -14,9 +14,17 @@ import { buildProUrl } from '@/lib/utils'
 
 interface TokenDashboardProps {
   onBackToDashboard: () => void
+  shouldShowUpsell: boolean
 }
 
-export const TokenDashboard = ({ onBackToDashboard: _onBackToDashboard }: TokenDashboardProps) => {
+export const TokenDashboard = ({
+  onBackToDashboard: _onBackToDashboard,
+  shouldShowUpsell,
+}: TokenDashboardProps) => {
+  if (!shouldShowUpsell) {
+    return null
+  }
+
   const proUrl = buildProUrl({
     source: 'token-dashboard',
     medium: 'placeholder',

--- a/admin/ui/src/components/dashboard/topbar.tsx
+++ b/admin/ui/src/components/dashboard/topbar.tsx
@@ -5,9 +5,10 @@ import { buildProUrl, getDynamicCTAText, getWeekNumber } from '@/lib/utils'
 interface TopbarProps {
   currentPage: 'overview' | 'survey' | 'token-dashboard'
   onPageChange: (page: 'overview' | 'survey' | 'token-dashboard') => void
+  shouldShowUpsell: boolean
 }
 
-export const Topbar = ({ currentPage, onPageChange }: TopbarProps) => {
+export const Topbar = ({ currentPage, onPageChange, shouldShowUpsell }: TopbarProps) => {
   const weekNumber = getWeekNumber()
   const ctaText = getDynamicCTAText('header')
   const proUrl = buildProUrl({
@@ -40,26 +41,30 @@ export const Topbar = ({ currentPage, onPageChange }: TopbarProps) => {
                 <BarChart3 className="jwt-h-4 jwt-w-4" />
                 <span>Overview</span>
               </button>
-              <button
-                onClick={() => onPageChange('token-dashboard')}
-                className={`jwt-flex jwt-items-center jwt-space-x-2 jwt-px-3 jwt-py-2 jwt-rounded-md jwt-text-sm jwt-font-medium jwt-transition-colors ${
-                  currentPage === 'token-dashboard'
-                    ? 'jwt-bg-green-100 jwt-text-green-700'
-                    : 'jwt-text-slate-600 hover:jwt-text-slate-900 hover:jwt-bg-slate-100'
-                }`}
-              >
-                <span className="jwt-text-base">👑</span>
-                <span>Token Dashboard</span>
-              </button>
+              {shouldShowUpsell && (
+                <button
+                  onClick={() => onPageChange('token-dashboard')}
+                  className={`jwt-flex jwt-items-center jwt-space-x-2 jwt-px-3 jwt-py-2 jwt-rounded-md jwt-text-sm jwt-font-medium jwt-transition-colors ${
+                    currentPage === 'token-dashboard'
+                      ? 'jwt-bg-green-100 jwt-text-green-700'
+                      : 'jwt-text-slate-600 hover:jwt-text-slate-900 hover:jwt-bg-slate-100'
+                  }`}
+                >
+                  <span className="jwt-text-base">👑</span>
+                  <span>Token Dashboard</span>
+                </button>
+              )}
             </nav>
           </div>
 
           <div className="jwt-flex jwt-items-center jwt-space-x-4">
-            <Button className="jwt-text-white hover:jwt-text-white/90" asChild>
-              <a href={proUrl} target="_blank" rel="noopener noreferrer">
-                {ctaText}
-              </a>
-            </Button>
+            {shouldShowUpsell && (
+              <Button className="jwt-text-white hover:jwt-text-white/90" asChild>
+                <a href={proUrl} target="_blank" rel="noopener noreferrer">
+                  {ctaText}
+                </a>
+              </Button>
+            )}
           </div>
         </div>
       </div>

--- a/admin/ui/src/components/dashboard/topbar.tsx
+++ b/admin/ui/src/components/dashboard/topbar.tsx
@@ -1,21 +1,27 @@
 import { Button } from '@/components/ui/button'
-import { Rocket, BarChart3 } from 'lucide-react'
-import { buildProUrl, getDynamicCTAText, getWeekNumber } from '@/lib/utils'
+import { Rocket, BarChart3, Sparkles } from 'lucide-react'
+import { buildProUrl, formatCompactTokenCount, getTokenUsageCta } from '@/lib/utils'
 
 interface TopbarProps {
   currentPage: 'overview' | 'survey' | 'token-dashboard'
   onPageChange: (page: 'overview' | 'survey' | 'token-dashboard') => void
   shouldShowUpsell: boolean
+  tokensCreated: number
 }
 
-export const Topbar = ({ currentPage, onPageChange, shouldShowUpsell }: TopbarProps) => {
-  const weekNumber = getWeekNumber()
-  const ctaText = getDynamicCTAText('header')
+export const Topbar = ({
+  currentPage,
+  onPageChange,
+  shouldShowUpsell,
+  tokensCreated,
+}: TopbarProps) => {
+  const { message: ctaMessage, variant } = getTokenUsageCta()
+  const compactTokens = formatCompactTokenCount(tokensCreated)
   const proUrl = buildProUrl({
     source: 'dashboard',
     medium: 'header',
     campaign: 'pro-upgrade',
-    content: `cta-week-${(weekNumber % 4) + 1}`,
+    content: `token-usage-variant-${variant}`,
   })
 
   return (
@@ -57,13 +63,33 @@ export const Topbar = ({ currentPage, onPageChange, shouldShowUpsell }: TopbarPr
             </nav>
           </div>
 
-          <div className="jwt-flex jwt-items-center jwt-space-x-4">
+          <div className="jwt-flex jwt-items-center jwt-space-x-3">
             {shouldShowUpsell && (
-              <Button className="jwt-text-white hover:jwt-text-white/90" asChild>
-                <a href={proUrl} target="_blank" rel="noopener noreferrer">
-                  {ctaText}
+              <>
+                <a
+                  href={proUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="jwt-hidden lg:jwt-flex jwt-items-center jwt-gap-2 jwt-rounded-lg jwt-border jwt-border-emerald-200 jwt-bg-gradient-to-r jwt-from-emerald-50 jwt-to-lime-50 jwt-px-3 jwt-py-1.5 jwt-shadow-sm hover:jwt-shadow-md jwt-transition-shadow"
+                >
+                  <span className="jwt-inline-flex jwt-items-center jwt-justify-center jwt-h-5 jwt-w-5 jwt-rounded-full jwt-bg-emerald-500/15 jwt-text-emerald-700">
+                    <Sparkles className="jwt-h-3 jwt-w-3" />
+                  </span>
+                  <span className="jwt-text-xs jwt-font-semibold jwt-text-emerald-800">
+                    {compactTokens} tokens generated
+                  </span>
+                  <span className="jwt-text-xs jwt-text-emerald-700">- {ctaMessage}</span>
                 </a>
-              </Button>
+
+                <Button
+                  className="jwt-bg-emerald-600 hover:jwt-bg-emerald-500 jwt-text-white hover:jwt-text-white jwt-shadow-sm hover:jwt-shadow-md"
+                  asChild
+                >
+                  <a href={proUrl} target="_blank" rel="noopener noreferrer">
+                    See token details →
+                  </a>
+                </Button>
+              </>
             )}
           </div>
         </div>

--- a/admin/ui/src/components/ui/status-row.tsx
+++ b/admin/ui/src/components/ui/status-row.tsx
@@ -1,7 +1,7 @@
 import type React from 'react'
 
 interface StatusRowProps {
-  label: string
+  label: React.ReactNode
   children: React.ReactNode
 }
 

--- a/admin/ui/src/lib/utils.ts
+++ b/admin/ui/src/lib/utils.ts
@@ -9,7 +9,7 @@ export function cn(...inputs: ClassValue[]) {
  * Build a Pro URL with consistent UTM parameters
  */
 export function buildProUrl(params: {
-  source: 'dashboard' | 'plugin-list' | 'wp-menu' | 'survey'
+  source: 'dashboard' | 'plugin-list' | 'wp-menu' | 'survey' | 'token-dashboard'
   medium: string
   campaign: string
   content: string

--- a/admin/ui/src/lib/utils.ts
+++ b/admin/ui/src/lib/utils.ts
@@ -16,7 +16,7 @@ export function buildProUrl(params: {
   path?: string
 }): string {
   const baseUrl = 'https://jwtauth.pro'
-  const fullPath = params.path || '/upgrade'
+  const fullPath = params.path || '/'
 
   const queryParams = new URLSearchParams({
     utm_source: params.source,

--- a/admin/ui/src/lib/utils.ts
+++ b/admin/ui/src/lib/utils.ts
@@ -62,3 +62,39 @@ export function getDynamicCTAText(location: 'header' | 'plugin-list'): string {
 
   return location === 'header' ? headerCTAs[weekIndex] : pluginListCTAs[weekIndex]
 }
+
+/**
+ * Format token count for compact UI display.
+ */
+export function formatCompactTokenCount(count: number): string {
+  if (count >= 1000000) {
+    return `${(count / 1000000).toFixed(1).replace(/\.0$/, '')}M`
+  }
+
+  if (count >= 1000) {
+    return `${(count / 1000).toFixed(1).replace(/\.0$/, '')}K`
+  }
+
+  return `${count}`
+}
+
+/**
+ * Get rotating CTA copy focused on token analytics value.
+ */
+export function getTokenUsageCta(): { message: string; variant: number } {
+  const weekNumber = getWeekNumber()
+  const variants = [
+    'ready for deeper monitoring',
+    'see top consumers and suspicious spikes',
+    'see token details',
+    'unlock token analytics',
+    'spot unusual token activity',
+  ]
+
+  const variant = weekNumber % variants.length
+
+  return {
+    message: variants[variant],
+    variant: variant + 1,
+  }
+}

--- a/admin/ui/src/lib/wordpress-api.ts
+++ b/admin/ui/src/lib/wordpress-api.ts
@@ -16,6 +16,11 @@ declare global {
         pluginCount: number
         signingAlgorithm: string
       }
+      upsell?: {
+        shouldShowUpsell: boolean
+        daysActive: number
+        tokensCreated: number
+      }
     }
   }
 }
@@ -89,6 +94,11 @@ export interface DashboardData {
     dismissalCount: number
     lastDismissedAt: string | null
     shouldShow: boolean
+  }
+  upsell: {
+    shouldShowUpsell: boolean
+    daysActive: number
+    tokensCreated: number
   }
 }
 
@@ -271,6 +281,11 @@ export class WordPressAPI {
         },
         surveyStatus: { completed: false },
         surveyDismissal: { dismissalCount: 0, lastDismissedAt: null, shouldShow: true },
+        upsell: {
+          shouldShowUpsell: false,
+          daysActive: 0,
+          tokensCreated: 0,
+        },
       }
     }
   }

--- a/composer.json
+++ b/composer.json
@@ -31,11 +31,12 @@
     "squizlabs/php_codesniffer": "3.*",
     "wp-coding-standards/wpcs": "*",
     "php-stubs/wordpress-stubs": "^6.3",
-    "phpunit/phpunit": "^9.5",
+    "phpunit/phpunit": "^9.6.33",
     "brain/monkey": "^2.6",
     "mockery/mockery": "^1.5",
     "wp-phpunit/wp-phpunit": "^6.7",
     "yoast/phpunit-polyfills": "^3.0",
-    "php-stubs/wordpress-tests-stubs": "^6.6"
+    "php-stubs/wordpress-tests-stubs": "^6.6",
+    "doctrine/instantiator": ">=2.0 <2.1"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b7df9a65181bbc0b2f2149d043e17268",
+    "content-hash": "de1d3b3bdacd1c98c035d9d71c8022e3",
     "packages": [
         {
             "name": "composer/installers",
@@ -641,16 +641,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.13.3",
+            "version": "1.13.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "faed855a7b5f4d4637717c2b3863e277116beb36"
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/faed855a7b5f4d4637717c2b3863e277116beb36",
-                "reference": "faed855a7b5f4d4637717c2b3863e277116beb36",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
                 "shasum": ""
             },
             "require": {
@@ -689,7 +689,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.3"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
             },
             "funding": [
                 {
@@ -697,20 +697,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-05T12:25:42+00:00"
+            "time": "2025-08-01T08:46:24+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.5.0",
+            "version": "v5.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "ae59794362fe85e051a58ad36b289443f57be7a9"
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/ae59794362fe85e051a58ad36b289443f57be7a9",
-                "reference": "ae59794362fe85e051a58ad36b289443f57be7a9",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
                 "shasum": ""
             },
             "require": {
@@ -729,7 +729,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-master": "5.x-dev"
                 }
             },
             "autoload": {
@@ -753,9 +753,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.5.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
             },
-            "time": "2025-05-31T08:24:38+00:00"
+            "time": "2025-12-06T11:56:16+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -1462,16 +1462,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.23",
+            "version": "9.6.34",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "43d2cb18d0675c38bd44982a5d1d88f6d53d8d95"
+                "reference": "b36f02317466907a230d3aa1d34467041271ef4a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/43d2cb18d0675c38bd44982a5d1d88f6d53d8d95",
-                "reference": "43d2cb18d0675c38bd44982a5d1d88f6d53d8d95",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b36f02317466907a230d3aa1d34467041271ef4a",
+                "reference": "b36f02317466907a230d3aa1d34467041271ef4a",
                 "shasum": ""
             },
             "require": {
@@ -1482,7 +1482,7 @@
                 "ext-mbstring": "*",
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.13.1",
+                "myclabs/deep-copy": "^1.13.4",
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
                 "php": ">=7.3",
@@ -1493,11 +1493,11 @@
                 "phpunit/php-timer": "^5.0.3",
                 "sebastian/cli-parser": "^1.0.2",
                 "sebastian/code-unit": "^1.0.8",
-                "sebastian/comparator": "^4.0.8",
+                "sebastian/comparator": "^4.0.10",
                 "sebastian/diff": "^4.0.6",
                 "sebastian/environment": "^5.1.5",
-                "sebastian/exporter": "^4.0.6",
-                "sebastian/global-state": "^5.0.7",
+                "sebastian/exporter": "^4.0.8",
+                "sebastian/global-state": "^5.0.8",
                 "sebastian/object-enumerator": "^4.0.4",
                 "sebastian/resource-operations": "^3.0.4",
                 "sebastian/type": "^3.2.1",
@@ -1545,7 +1545,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.23"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.34"
             },
             "funding": [
                 {
@@ -1569,7 +1569,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-05-02T06:40:34+00:00"
+            "time": "2026-01-27T05:45:00+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -1740,16 +1740,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "4.0.8",
+            "version": "4.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "fa0f136dd2334583309d32b62544682ee972b51a"
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/fa0f136dd2334583309d32b62544682ee972b51a",
-                "reference": "fa0f136dd2334583309d32b62544682ee972b51a",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d",
                 "shasum": ""
             },
             "require": {
@@ -1802,15 +1802,27 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.8"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.10"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2022-09-14T12:41:17+00:00"
+            "time": "2026-01-24T09:22:56+00:00"
         },
         {
             "name": "sebastian/complexity",
@@ -2000,16 +2012,16 @@
         },
         {
             "name": "sebastian/exporter",
-            "version": "4.0.6",
+            "version": "4.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "78c00df8f170e02473b682df15bfcdacc3d32d72"
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/78c00df8f170e02473b682df15bfcdacc3d32d72",
-                "reference": "78c00df8f170e02473b682df15bfcdacc3d32d72",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/14c6ba52f95a36c3d27c835d65efc7123c446e8c",
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c",
                 "shasum": ""
             },
             "require": {
@@ -2065,28 +2077,40 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.6"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.8"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-03-02T06:33:00+00:00"
+            "time": "2025-09-24T06:03:27+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.7",
+            "version": "5.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9"
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9",
-                "reference": "bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
                 "shasum": ""
             },
             "require": {
@@ -2129,15 +2153,27 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.7"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.8"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/global-state",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-03-02T06:35:11+00:00"
+            "time": "2025-08-10T07:10:35+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
@@ -2310,16 +2346,16 @@
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "4.0.5",
+            "version": "4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1"
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
-                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/539c6691e0623af6dc6f9c20384c120f963465a0",
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0",
                 "shasum": ""
             },
             "require": {
@@ -2361,15 +2397,27 @@
             "homepage": "https://github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.5"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.6"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2023-02-03T06:07:39+00:00"
+            "time": "2025-08-10T06:57:39+00:00"
         },
         {
             "name": "sebastian/resource-operations",
@@ -2620,16 +2668,16 @@
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.2.3",
+            "version": "1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2"
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
-                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
                 "shasum": ""
             },
             "require": {
@@ -2658,7 +2706,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/1.2.3"
+                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
             },
             "funding": [
                 {
@@ -2666,7 +2714,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-03T12:36:25+00:00"
+            "time": "2025-11-17T20:03:58+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",

--- a/includes/class-jwt-auth.php
+++ b/includes/class-jwt-auth.php
@@ -174,11 +174,11 @@ class Jwt_Auth {
 		$plugin_admin = new Jwt_Auth_Admin( $this->get_plugin_name(), $this->get_version() );
 		$this->loader->add_action( 'admin_menu', $plugin_admin, 'register_menu_page' );
 		$this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_plugin_assets' );
+		$this->loader->add_action( 'admin_init', $plugin_admin, 'track_install_date' );
 		$this->loader->add_action( 'admin_init', $plugin_admin, 'register_plugin_settings' );
 		$this->loader->add_action( 'rest_api_init', $plugin_admin, 'register_plugin_settings' );
 		$this->loader->add_action( 'rest_api_init', $plugin_admin, 'register_admin_rest_routes' );
 		$this->loader->add_action( 'admin_notices', $plugin_admin, 'display_all_notices' );
-		$this->loader->add_filter( 'plugin_action_links', $plugin_admin, 'add_action_link', 10, 2 );
 	}
 
 	/**

--- a/jwt-auth.php
+++ b/jwt-auth.php
@@ -65,6 +65,83 @@ function jwt_auth_share_data() {
 add_action( 'jwt_auth_share_data', 'jwt_auth_share_data' );
 
 /**
+ * Track plugin install date and initialize usage counters.
+ *
+ * This runs on activation for new installs.
+ *
+ * @return void
+ */
+function activate_jwt_auth() {
+	if ( ! get_option( 'jwt_auth_install_date', false ) ) {
+		update_option( 'jwt_auth_install_date', time() );
+	}
+
+	if ( get_option( 'jwt_auth_tokens_created', null ) === null ) {
+		update_option( 'jwt_auth_tokens_created', 0 );
+	}
+}
+
+/**
+ * Ensure install date is tracked for existing installs.
+ *
+ * Existing users that upgrade to this version get a backfilled install date
+ * to avoid hiding upsells for another week.
+ *
+ * @return void
+ */
+function jwt_auth_track_install_date() {
+	if ( get_option( 'jwt_auth_install_date', false ) ) {
+		return;
+	}
+
+	update_option( 'jwt_auth_install_date', time() - ( 8 * DAY_IN_SECONDS ) );
+
+	if ( get_option( 'jwt_auth_tokens_created', null ) === null ) {
+		update_option( 'jwt_auth_tokens_created', 0 );
+	}
+}
+
+/**
+ * Increment total created JWT tokens counter.
+ *
+ * @return void
+ */
+function jwt_auth_increment_tokens_created() {
+	$count = (int) get_option( 'jwt_auth_tokens_created', 0 );
+	update_option( 'jwt_auth_tokens_created', $count + 1 );
+}
+
+/**
+ * Determine if upsell CTAs should be shown based on usage.
+ *
+ * @return bool
+ */
+function jwt_auth_should_show_upsell() {
+	$install_date = (int) get_option( 'jwt_auth_install_date', time() );
+	$days_active = ( time() - $install_date ) / DAY_IN_SECONDS;
+	$tokens_created = (int) get_option( 'jwt_auth_tokens_created', 0 );
+
+	return $days_active >= 7 || $tokens_created >= 20;
+}
+
+/**
+ * Get upsell metrics for UI/API usage.
+ *
+ * @return array<string, int|bool>
+ */
+function jwt_auth_get_upsell_metrics() {
+	$install_date = (int) get_option( 'jwt_auth_install_date', time() );
+	$days_active = (int) floor( ( time() - $install_date ) / DAY_IN_SECONDS );
+	$tokens_created = (int) get_option( 'jwt_auth_tokens_created', 0 );
+
+	return [
+		'shouldShowUpsell' => jwt_auth_should_show_upsell(),
+		'daysActive'       => max( 0, $days_active ),
+		'tokensCreated'    => $tokens_created,
+	];
+}
+
+/**
  * This runs during plugin deactivation.
  */
 function deactivate_jwt_auth() {
@@ -75,6 +152,7 @@ function deactivate_jwt_auth() {
  * Hook into the action that'll fire during plugin deactivation
  */
 register_deactivation_hook( __FILE__, 'deactivate_jwt_auth' );
+register_activation_hook( __FILE__, 'activate_jwt_auth' );
 
 /**
  * Begins execution of the plugin.

--- a/jwt-auth.php
+++ b/jwt-auth.php
@@ -15,7 +15,7 @@
  * Plugin Name:       JWT Authentication for WP-API
  * Plugin URI:        https://enriquechavez.co
  * Description:       Extends the WP REST API using JSON Web Tokens Authentication as an authentication method.
- * Version:           1.4.1
+ * Version:           1.5.0
  * Author:            Enrique Chavez
  * Author URI:        https://enriquechavez.co
  * License:           GPL-2.0+
@@ -87,6 +87,7 @@ function activate_jwt_auth() {
  * Existing users that upgrade to this version get a backfilled install date
  * to avoid hiding upsells for another week.
  *
+ * @since 1.5.0
  * @return void
  */
 function jwt_auth_track_install_date() {
@@ -104,6 +105,7 @@ function jwt_auth_track_install_date() {
 /**
  * Increment total created JWT tokens counter.
  *
+ * @since 1.5.0
  * @return void
  */
 function jwt_auth_increment_tokens_created() {
@@ -114,6 +116,7 @@ function jwt_auth_increment_tokens_created() {
 /**
  * Determine if upsell CTAs should be shown based on usage.
  *
+ * @since 1.5.0
  * @return bool
  */
 function jwt_auth_should_show_upsell() {
@@ -127,6 +130,7 @@ function jwt_auth_should_show_upsell() {
 /**
  * Get upsell metrics for UI/API usage.
  *
+ * @since 1.5.0
  * @return array<string, int|bool>
  */
 function jwt_auth_get_upsell_metrics() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8148,28 +8148,6 @@
         "concat-map": "0.0.1"
       }
     },
-    "node_modules/babel-plugin-istanbul/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/babel-plugin-istanbul/node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -11049,13 +11027,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -11256,9 +11227,10 @@
       }
     },
     "node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -11765,18 +11737,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
       }
     },
     "node_modules/inherits": {
@@ -15094,16 +15054,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -15514,16 +15464,6 @@
         "node": ">= 16"
       }
     },
-    "node_modules/postman-request/node_modules/qs": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
-      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
     "node_modules/postman-request/node_modules/uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -15726,9 +15666,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -86,5 +86,9 @@
     "react-syntax-highlighter": "^15.6.3",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7"
+  },
+  "overrides": {
+    "qs": "6.14.2",
+    "glob": "10.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-api-jwt-auth",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "WordPress plugin that provides JWT authentication for WP REST API",
   "private": true,
   "scripts": {

--- a/public/class-jwt-auth-public.php
+++ b/public/class-jwt-auth-public.php
@@ -196,6 +196,8 @@ class Jwt_Auth_Public {
 			'user_display_name' => $user->data->display_name,
 		];
 
+		jwt_auth_increment_tokens_created();
+
 		/** Let the user modify the data before send it back */
 		return apply_filters( 'jwt_auth_token_before_dispatch', $data, $user );
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Tags: oauth, jwt, json web authentication, wp-api, rest api
 Requires at least: 4.2
 Tested up to: 6.9.1
 Requires PHP: 7.4.0
-Stable tag: 1.4.1
+Stable tag: 1.5.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -424,6 +424,13 @@ Priority support is included with [JWT Authentication PRO](https://jwtauth.pro/?
 JWT authentication is very secure when implemented correctly. Make sure to use a strong secret key and keep it confidential. [JWT Auth PRO](https://jwtauth.pro/?utm_source=wp_plugin_readme&utm_medium=link&utm_campaign=pro_promotion&utm_content=faq_security_link) offers additional security features like rate limiting and token revocation.
 
 == Changelog ==
+= 1.5.0 =
+* Security: Updated dependencies to latest secure versions (deep-copy, php-parser, phpunit)
+* Feature: Smart upgrade prompts that appear based on actual plugin usage rather than immediately after installation
+* Feature: Usage-based notifications showing real token activity in the dashboard for more relevant upgrade recommendations
+* Improvement: Better first-time experience - new users won't see upgrade prompts until they've had a chance to use the plugin
+* Fix: UTM tracking on upgrade links now works correctly to measure campaign effectiveness
+
 = 1.4.1 =
 * Enhancement: Updated lucide-react from 0.294.0 to 0.541.0 - Latest icon library improvements with new icons and performance optimizations
 * Enhancement: Updated tailwind-merge from 2.6.0 to 3.3.1 - Enhanced CSS utility merging capabilities for better styling performance

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: tmeister
 Donate link: https://github.com/sponsors/Tmeister
 Tags: oauth, jwt, json web authentication, wp-api, rest api
 Requires at least: 4.2
-Tested up to: 6.8.1
+Tested up to: 6.9.1
 Requires PHP: 7.4.0
 Stable tag: 1.4.1
 License: GPLv2 or later

--- a/tests/Unit/JwtAuthAdminIntegrationTest.php
+++ b/tests/Unit/JwtAuthAdminIntegrationTest.php
@@ -278,6 +278,7 @@ class JwtAuthAdminIntegrationTest extends TestCase {
         $this->assertArrayHasKey('jwtStatus', $data);
         $this->assertArrayHasKey('surveyStatus', $data);
         $this->assertArrayHasKey('surveyDismissal', $data);
+        $this->assertArrayHasKey('upsell', $data);
 
         // Verify settings data structure (should be unwrapped from jwt_auth_options)
         $this->assertArrayHasKey('share_data', $data['settings']);
@@ -296,6 +297,11 @@ class JwtAuthAdminIntegrationTest extends TestCase {
         $this->assertArrayHasKey('dismissalCount', $data['surveyDismissal']);
         $this->assertArrayHasKey('shouldShow', $data['surveyDismissal']);
         $this->assertEquals(1, $data['surveyDismissal']['dismissalCount']);
+
+        // Verify upsell structure
+        $this->assertArrayHasKey('shouldShowUpsell', $data['upsell']);
+        $this->assertArrayHasKey('daysActive', $data['upsell']);
+        $this->assertArrayHasKey('tokensCreated', $data['upsell']);
     }
 
     public function test_get_dashboard_data_with_completed_survey()

--- a/tests/Unit/JwtAuthPublicIntegrationTest.php
+++ b/tests/Unit/JwtAuthPublicIntegrationTest.php
@@ -46,6 +46,25 @@ class JwtAuthPublicIntegrationTest extends TestCase {
         $this->assertEquals($user->display_name, $result['user_display_name']);
     }
 
+    public function test_generate_token_increments_tokens_counter() {
+        update_option('jwt_auth_tokens_created', 0);
+
+        $this->createTestUser([
+            'user_login' => 'counteruser',
+            'user_pass' => 'counterpass123'
+        ]);
+
+        $request = new WP_REST_Request('POST');
+        $request->set_param('username', 'counteruser');
+        $request->set_param('password', 'counterpass123');
+
+        $result = $this->public->generate_token($request);
+
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('token', $result);
+        $this->assertSame(1, (int) get_option('jwt_auth_tokens_created', 0));
+    }
+
     public function test_generate_token_with_invalid_credentials() {
         $request = new WP_REST_Request('POST');
         $request->set_param('username', 'nonexistent');

--- a/tests/Unit/JwtAuthUpsellIntegrationTest.php
+++ b/tests/Unit/JwtAuthUpsellIntegrationTest.php
@@ -1,0 +1,80 @@
+<?php
+
+require_once __DIR__ . '/TestCase.php';
+
+/**
+ * Integration tests for upsell usage tracking helpers.
+ */
+class JwtAuthUpsellIntegrationTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        delete_option('jwt_auth_install_date');
+        delete_option('jwt_auth_tokens_created');
+
+        parent::tearDown();
+    }
+
+    public function test_track_install_date_backfills_existing_install(): void
+    {
+        delete_option('jwt_auth_install_date');
+        delete_option('jwt_auth_tokens_created');
+
+        jwt_auth_track_install_date();
+
+        $install_date = (int) get_option('jwt_auth_install_date', 0);
+        $tokens_created = (int) get_option('jwt_auth_tokens_created', -1);
+
+        $this->assertGreaterThan(0, $install_date);
+        $this->assertEquals(0, $tokens_created);
+        $this->assertEqualsWithDelta(time() - (8 * DAY_IN_SECONDS), $install_date, 5);
+    }
+
+    public function test_should_show_upsell_false_for_new_install(): void
+    {
+        update_option('jwt_auth_install_date', time());
+        update_option('jwt_auth_tokens_created', 0);
+
+        $this->assertFalse(jwt_auth_should_show_upsell());
+    }
+
+    public function test_should_show_upsell_true_after_seven_days(): void
+    {
+        update_option('jwt_auth_install_date', time() - (8 * DAY_IN_SECONDS));
+        update_option('jwt_auth_tokens_created', 0);
+
+        $this->assertTrue(jwt_auth_should_show_upsell());
+    }
+
+    public function test_should_show_upsell_true_after_twenty_tokens(): void
+    {
+        update_option('jwt_auth_install_date', time());
+        update_option('jwt_auth_tokens_created', 20);
+
+        $this->assertTrue(jwt_auth_should_show_upsell());
+    }
+
+    public function test_increment_tokens_created_increases_counter(): void
+    {
+        update_option('jwt_auth_tokens_created', 0);
+
+        jwt_auth_increment_tokens_created();
+
+        $this->assertSame(1, (int) get_option('jwt_auth_tokens_created', 0));
+    }
+
+    public function test_get_upsell_metrics_returns_expected_shape(): void
+    {
+        update_option('jwt_auth_install_date', time());
+        update_option('jwt_auth_tokens_created', 2);
+
+        $metrics = jwt_auth_get_upsell_metrics();
+
+        $this->assertArrayHasKey('shouldShowUpsell', $metrics);
+        $this->assertArrayHasKey('daysActive', $metrics);
+        $this->assertArrayHasKey('tokensCreated', $metrics);
+        $this->assertIsBool($metrics['shouldShowUpsell']);
+        $this->assertIsInt($metrics['daysActive']);
+        $this->assertIsInt($metrics['tokensCreated']);
+    }
+}

--- a/tests/Unit/TestCase.php
+++ b/tests/Unit/TestCase.php
@@ -26,6 +26,9 @@ class TestCase extends WP_UnitTestCase
     protected function loadPluginClasses(): void
     {
         $plugin_dir = dirname(dirname(__DIR__));
+
+        // Load plugin bootstrap to register global helper functions used by admin/public classes.
+        require_once $plugin_dir . '/jwt-auth.php';
         
         // Load dependencies
         require_once $plugin_dir . '/includes/vendor/autoload.php';


### PR DESCRIPTION
## Summary
This PR introduces usage-based gating for upgrade CTAs and prepares the plugin for v1.5.0 release.

## Changes

### Features
- **Smart upgrade prompts**: CTAs now appear based on actual plugin usage rather than immediately after installation
- **Usage-based notifications**: Dashboard shows real token activity for more relevant upgrade recommendations
- **Better first-time experience**: New users won't see upgrade prompts until they've had meaningful usage

### Fixes
- **UTM tracking**: Fixed tracking on upgrade links to measure campaign effectiveness

### Security
- Updated dependencies to latest secure versions (deep-copy, php-parser, phpunit)

### Version Updates
- Bumped version to 1.5.0 across all files
- Added @since 1.5.0 documentation tags
- Updated changelog in readme.txt

## Commits
- chore(release): bump version to 1.5.0
- feat(upsell): surface token usage and harden deps
- fix(upsell): restore pro root url and test bootstrap  
- feat(upsell): gate upgrade ctas by usage